### PR TITLE
don't allow calls to initialize on UUPS impl

### DIFF
--- a/src/StateBridge.sol
+++ b/src/StateBridge.sol
@@ -35,6 +35,10 @@ contract StateBridge is IBridge, Initializable, UUPSUpgradeable {
         _;
     }
 
+    constructor() {
+        _disableInitializers();
+    }
+
     /// @notice Sets the addresses for all the WorldID target chains
     /// @param _worldIDIdentityManager Deployment address of the WorldID Identity Manager contract
     /// @param _opWorldIDAddress Address of the Optimism contract that will receive the new root and timestamp

--- a/test/StateBridge.t.sol
+++ b/test/StateBridge.t.sol
@@ -59,4 +59,10 @@ contract StateBridgeTest is PRBTest, StdCheats {
 
         assertEq(abi.decode(result, (uint256)), 420);
     }
+
+    function testCannotInitializeUUPSImplementationDirectly() public {
+        StateBridge stateBridge = new StateBridge();
+        vm.expectRevert("Initializable: contract is already initialized");
+        stateBridge.initialize(address(this), address(0), address(0));
+    }
 }


### PR DESCRIPTION
The UUPS implementation isn't currently being initialized on deployment. This isn't a huge deal now that OZ protects functions with `DELEGATECALL`'s with the `onlyProxy` [modifier](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/91e8d0ba3c3beb8a1db31310d8599664e48639ef/contracts/proxy/utils/UUPSUpgradeable.sol#L68-L86) requiring that the caller be a proxy and preventing someone from destroying the implementation contract. However, someone could become the owner/ set other state variables on the uninitialized implementation. For that reason, I've added a call to `_disableInitalizers` in the constructor and added a test that checks a call to `initialize` directly on the implementation should revert. 